### PR TITLE
Update Schedule Colors

### DIFF
--- a/MAKE-website/css/main.css
+++ b/MAKE-website/css/main.css
@@ -1607,7 +1607,7 @@ table tr td button {
   background-color: var(--shift-1);
 }
 
-.highlight-1 {
+.stewards-1.highlight-1 {
   background-color: var(--shift-1) !important;
 }
 
@@ -1615,21 +1615,29 @@ table tr td button {
   background-color: var(--shift-2);
 }
 
-.highlight-2 {
-  background-color: var(--shift-2) !important;
+.stewards-2.highlight-2 {
+  background-color: var(--shift-2);
 }
 
 .stewards-3 {
   background-color: var(--shift-3);
 }
 
-.highlight-3 {
-  background-color: var(--shift-3) !important;
+.stewards-3.highlight-3 {
+  background-color: var(--shift-3);
 }
 
 .head-steward {
   background-color: var(--theme-color-1);
   color: var(--black);
+}
+
+.head-steward.highlight-1 {
+  background-color: var(--alt-make-color);
+}
+
+.head-steward.highlight-2 .head-steward.highlight-3 {
+  background-color: var(--make-color);
 }
 
 .stewards-legend {

--- a/MAKE-website/css/main.css
+++ b/MAKE-website/css/main.css
@@ -1607,15 +1607,15 @@ table tr td button {
   background-color: var(--shift-1);
 }
 
-.stewards-1.highlight-1 {
-  background-color: var(--shift-1) !important;
+.highlight-1 {
+  background-color: var(--shift-1);
 }
 
 .stewards-2 {
   background-color: var(--shift-2);
 }
 
-.stewards-2.highlight-2 {
+.highlight-2 {
   background-color: var(--shift-2);
 }
 
@@ -1623,7 +1623,7 @@ table tr td button {
   background-color: var(--shift-3);
 }
 
-.stewards-3.highlight-3 {
+.highlight-3 {
   background-color: var(--shift-3);
 }
 
@@ -1636,8 +1636,12 @@ table tr td button {
   background-color: var(--alt-make-color);
 }
 
-.head-steward.highlight-2 .head-steward.highlight-3 {
+.head-steward.highlight-2,.head-steward.highlight-3 {
   background-color: var(--make-color);
+}
+
+.head-steward.grayed-out {
+  color: var(--make-color);
 }
 
 .stewards-legend {

--- a/MAKE-website/kiosks/management.html
+++ b/MAKE-website/kiosks/management.html
@@ -767,7 +767,7 @@
     <script src="/scripts/page_schedule.js?v=2.11"></script>
     <script src="/scripts/utils.js?v=2.14"></script>
 
-    <script src="/kiosks/scripts/management.js?v=2.42"></script>
+    <script src="/kiosks/scripts/management.js?v=2.43"></script>
 </body>
 
 </html>

--- a/MAKE-website/kiosks/scripts/management.js
+++ b/MAKE-website/kiosks/scripts/management.js
@@ -3260,6 +3260,11 @@ function generateScheduleDivsAdmin() {
                 inner_div.classList.add(`stewards-${shift.stewards.length}`);
                 for (let uuid of shift.stewards) {
                     const user = state.users.find(user => user.uuid === uuid);
+                    
+                    if (!user) {
+                        console.log(`Scheduled steward with uuid ${uuid} not found`);
+                        continue;
+                    }
 
                     if (user.role == "head_steward") {
                         inner_div.classList.add("head-steward");


### PR DESCRIPTION
Improve the main Schedule tab to have better coloring when looking for what proficiencies are available on what shifts. Previously, head steward shift colors were overrided by other selector colors, which has now been fixed.

Also, add a backup test case to the management schedule that checks if a steward user exists before adding them to the schedule.