### PR TITLE
Update link to webmaster email and management email to be dynamically loaded from the config.

### DIFF
--- a/MAKE-server/routes/routes_misc.py
+++ b/MAKE-server/routes/routes_misc.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 
-from config import QUIZ_IDS, VERSION, API_KEY_SCOPES
+from config import QUIZ_IDS, VERSION, API_KEY_SCOPES, WEBMASTER_EMAIL, MAKERSPACE_MANAGEMENT_EMAIL
 import utilities
 from utilities import validate_api_key
 from db_schema import *
@@ -348,3 +348,17 @@ async def route_get_quiz_results(request: Request):
     quizzes = [QuizResponse(**attempt) for attempt in quiz_data]
 
     return quizzes
+
+@misc_router.get("/get_webmaster_email")
+async def route_get_webmaster_email():
+    logging.getLogger().setLevel(logging.INFO)
+    logging.info("Getting Webmaster email...")
+
+    return WEBMASTER_EMAIL
+
+@misc_router.get("/get_makerspace_management_email")
+async def route_get_makerspace_management_email():
+    logging.getLogger().setLevel(logging.INFO)
+    logging.info("Getting Makerspace Management email...")
+
+    return MAKERSPACE_MANAGEMENT_EMAIL

--- a/MAKE-server/template_config.py
+++ b/MAKE-server/template_config.py
@@ -25,7 +25,7 @@ BAMBULABS_PASS = "PASSWORD"
 # Misc Emails
 MAKERSPACE_MANAGEMENT_EMAIL = "makerspace-management-l@g.hmc.edu"
 MAKERSPACE_MANAGER_EMAIL = "kneal@g.hmc.edu"
-WEBMASTER_EMAIL = "evazquez@g.hmc.edu"
+WEBMASTER_EMAIL = "wkirkland@g.hmc.edu"
 
 # Email passwords and secrets
 GMAIL_EMAIL = "EMAIL"

--- a/MAKE-website/index.html
+++ b/MAKE-website/index.html
@@ -1120,7 +1120,7 @@
 <script src="scripts/libs/color-thief.umd.js"></script>
 
 <script src="scripts/utils.js?v=2.15"></script>
-<script src="scripts/page_settings.js?v=2.3"></script>
+<script src="scripts/page_settings.js?v=2.4"></script>
 
 <script src="scripts/page_home.js?v=2.9"></script>
 <script src="scripts/page_stewards.js?v=2.11"></script>

--- a/MAKE-website/md/settings.md
+++ b/MAKE-website/md/settings.md
@@ -16,7 +16,7 @@
 </div>
 
 ## Contact
-Email Ethan Vazquez (<a href="mailto:evazquez@g.hmc.edu">evazquez@g.hmc.edu</a>) for any questions or concerns about this website.
+For any questions or concerns about this website, please email the Makerspace Webmaster directly at <a href="mailto:{{WEBMASTER_EMAIL}}">{{WEBMASTER_EMAIL}}</a>.
 If you find a bug, please include a screenshot and/or a brief description on how to reproduce the bug.
 
-For anything else, please contact us at <a href="mailto:makerspace-management-l@g.hmc.edu">makerspace-management-l@g.hmc.edu</a>.
+For other questions about the Makerspace, please contact Makerspace Management at <a href="mailto:{{MANAGEMENT_EMAIL}}">{{MANAGEMENT_EMAIL}}</a>.

--- a/MAKE-website/scripts/page_settings.js
+++ b/MAKE-website/scripts/page_settings.js
@@ -1,7 +1,25 @@
+// Render the settings.md page as html
 renderMD("md/settings.md", "settings").then(() => {
     setTimeout(() => {
         fetchStatus();
     }, 100);
+
+    // After the html has loaded, fetch the Makerspace Management and Webmaster
+    // emails from the config and replace their respective placeholders.
+    fetch(`${API}/misc/get_makerspace_management_email`, {
+        method: "GET",
+    }).then(async (response) => {
+        const email = await response.json();
+        const settingsDiv = document.getElementById(`settings-content`);
+        settingsDiv.innerHTML = settingsDiv.innerHTML.replace(/{{MANAGEMENT_EMAIL}}/g, email);
+    });
+    fetch(`${API}/misc/get_webmaster_email`, {
+        method: "GET",
+    }).then(async (response) => {
+        const email = await response.json();
+        const settingsDiv = document.getElementById(`settings-content`);
+        settingsDiv.innerHTML = settingsDiv.innerHTML.replace(/{{WEBMASTER_EMAIL}}/g, email);
+    });
 });
 
 async function fetchStatus() {


### PR DESCRIPTION
Closes #44 and #45.