### PR TITLE
Create long-term printer log and update existing status log to only keep one status per printer

### DIFF
--- a/MAKE-server/db_schema.py
+++ b/MAKE-server/db_schema.py
@@ -46,6 +46,7 @@ schema = [
     "shift_changes",
     "workshops",
     "printer_logs",
+    "printer_long_term_logs",
     "filament_logs",
     "api_keys",
     "ip_logs",
@@ -89,6 +90,7 @@ Define the schema for the database.
     shifts: List[Shift],
     workshops: List[Workshop],
     printer_logs: List[PrinterLog],
+    printer_long_term_logs: List[PrinterLog],
     api_keys: List[APIKey],
 """
 

--- a/MAKE-server/routes/routes_machines.py
+++ b/MAKE-server/routes/routes_machines.py
@@ -43,13 +43,9 @@ async def route_get_printers(request: Request):
     db = MongoDB()
     collection = await db.get_collection("printer_logs")
 
-    # Get most recent logs, then sort by time and pick
-    # the most recent log for each printer
+    # Get the most recent log for each printer
     printers_list = await collection.find().to_list(length=None)
     printers = {}
-
-    if len(printers_list) > 15:
-        printers_list = printers_list[15:]
             
     for printer in printers_list:
         printers[printer["printer_name"]] = PrinterLog(**printer)


### PR DESCRIPTION
Closes #36. Request by Inventory department, to be used for data analysis of failed print frequency. 