### PR TITLE
Checkouts until close fixed

### DIFF
--- a/MAKE-website/kiosks/checkout_kiosk.html
+++ b/MAKE-website/kiosks/checkout_kiosk.html
@@ -174,7 +174,6 @@
 
     <script src="/scripts/page_inventory.js?v=2.11"></script>
     <script src="/scripts/page_quiz_info.js?v=2.5"></script>
-
     <script src="/kiosks/scripts/checkout.js?v=2.7"></script>
 </body>
 

--- a/MAKE-website/kiosks/management.html
+++ b/MAKE-website/kiosks/management.html
@@ -821,7 +821,7 @@
     <script src="/scripts/page_quiz_info.js?v=2.5"></script>
     <script src="/scripts/page_checkouts.js?v=2.3"></script>
     <script src="/scripts/page_student_storage.js?v=2.3"></script>
-    <script src="/scripts/page_schedule.js?v=2.11"></script>
+    <script src="/scripts/page_schedule.js?v=2.12"></script>
     <script src="/scripts/utils.js?v=2.17"></script>
 
     <script src="/kiosks/scripts/management.js?v=2.46"></script>

--- a/MAKE-website/kiosks/scripts/management.js
+++ b/MAKE-website/kiosks/scripts/management.js
@@ -751,7 +751,7 @@ async function downloadSchedule() {
         }
     }
     for (let shift of validShifts) {
-        csvArray[hoursToIndex[moment(shift.timestamp_start.split("-")[0], 'h:mm A').hour()]][DAYS_TO_INDEX[shift.day]] = shift.stewards.join(" | ")
+        csvArray[hoursToIndex[moment(shift.timestamp_start.split("-")[0], 'h:mm A').hour()]][DAYS_TO_INDEX[shift.day]+1] = shift.stewards.join(" | ")
     }
 
     const csv = csvArray.map(row =>

--- a/MAKE-website/scripts/utils.js
+++ b/MAKE-website/scripts/utils.js
@@ -167,11 +167,50 @@ const PROFICIENCIES = [
     "Welding",
 ] // Keep this sorted
 
+WORKING_HOURS = {
+    "Sunday": {
+        start: 14,
+        end: 23,
+    },
+    "Monday": {
+        start: 14,
+        end: 23,
+    },
+    "Tuesday": {
+        start: 14,
+        end: 23,
+    },
+    "Wednesday": {
+        start: 14,
+        end: 23,
+    },
+    "Thursday": {
+        start: 14,
+        end: 23,
+    },
+    "Friday": {
+        start: 14,
+        end: 20,
+    },
+    "Saturday": {
+        start: 14,
+        end: 20,
+    },
+}
+
+function getEarliestWorkingHour() {
+    return Math.min(...Object.values(WORKING_HOURS).map(hours => hours.start));
+}
+
+function getLatestWorkingHour() {
+    return Math.max(...Object.values(WORKING_HOURS).map(hours => hours.end));
+}
+
 const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
 const TWENTY_FOUR_HOURS_TO_STRING = {0: "12:00 AM",  1: "1:00 AM", 2: "2:00 AM", 3: "3:00 AM",  4: "4:00 AM", 5: "5:00 AM", 6: "6:00 AM", 7: "7:00 AM",  8: "8:00 AM",  9: "9:00 AM", 10: "10:00 AM", 11: "11:00 AM",  12: "12:00 PM", 13: "1:00 PM", 14: "2:00 PM", 15: "3:00 PM", 16: "4:00 PM", 17: "5:00 PM", 18: "6:00 PM", 19: "7:00 PM", 20: "8:00 PM", 21: "9:00 PM", 22: "10:00 PM", 23: "11:00 PM" }
 
-const DAYS_TO_INDEX = {"Sunday": 1, "Monday": 2, "Tuesday": 3, "Wednesday": 4, "Thursday": 5, "Friday": 6, "Saturday": 7}
+const DAYS_TO_INDEX = {"Sunday": 0, "Monday": 1, "Tuesday": 2, "Wednesday": 3, "Thursday": 4, "Friday": 5, "Saturday": 6}
 
 // Cut off date for quizzes is on June 1st yearly
 // If a quiz was taken before this date, it is not counted


### PR DESCRIPTION
It now checks what day (based on the schedule now in utils) and extends checkout to the closing time of the working day. After working hours, it functions as the tomorrow checkout which checks out the item until closing hour of the next day ahead of the current one.