### PR TITLE
Update Deep Storage to be called The Crypt

### DIFF
--- a/MAKE-website/kiosks/inventory_editor.html
+++ b/MAKE-website/kiosks/inventory_editor.html
@@ -45,7 +45,7 @@
                         <option value="Electronics">Electronics Benches</option>
                         <option value="Composite">Composite Room</option>
                         <option value="Outdoor Storage">Outdoor Storage</option>
-                        <option value="Deep Storage">Deep Storage</option>
+                        <option value="The Crypt">The Crypt</option>
                         <option value="Other">Other</option>
                     </select>
                 </span>

--- a/MAKE-website/kiosks/scripts/inventory.js
+++ b/MAKE-website/kiosks/scripts/inventory.js
@@ -32,7 +32,7 @@ const ROOMS_HTML = (function (value) {return `
 <option ${value === "Composite" ? "selected" : ""} value="Composite">Composite Room</option>
 <option ${value === "Outdoor Storage" ? "selected" : ""} value="Outdoor Storage">Outdoor Storage</option>
 <option ${value === "Backstock" ? "selected" : ""} value="Backstock">Backstock</option>
-<option ${value === "Deep Storage" ? "selected" : ""} value="Deep Storage">Deep Storage</option>
+<option ${value === "The Crypt" ? "selected" : ""} value="The Crypt">The Crypt</option>
 <option ${value === "Other" ? "selected" : ""} value="Other">Other</option>
 `});
 


### PR DESCRIPTION
Quick fix to rename Deep Storage to The Crypt, since all items in Deep Storage have been moved.