### PR TITLE
Fix shift event duplication on frontend and backend

### DIFF
--- a/server/controllers/schedule.controller.ts
+++ b/server/controllers/schedule.controller.ts
@@ -607,16 +607,95 @@ export async function addShiftEventInSchedule(
     schedule_uuid: UUID,
     shift_uuid: UUID,
     event: TShiftEvent,
-): Promise<TSchedule | null> {
+) {
     const Schedules = mongoose.model("Schedule", Schedule);
 
-    // TODO: Consider deleting drop if assignee is the initiator of a pickup
-    return Schedules.findOneAndUpdate(
-        // Find the schedule by UUID
-        { uuid: schedule_uuid, "shifts.uuid": shift_uuid },
-        // Push the new event to the shift's history array
-        { $push: { "shifts.$.history": event } },
-        // Return the updated schedule
-        { returnDocument: "after" },
+    const schedule = await Schedules.findOne({ uuid: schedule_uuid });
+
+    if (!schedule) return null;
+
+    const shift = schedule.shifts.find((shift) => shift.uuid === shift_uuid);
+
+    if (!shift) return null;
+
+    // Find all events from this initiator on this date
+    const existing_events = shift.history.filter(
+        (e) =>
+            e.initiator === event.initiator &&
+            e.shift_date === event.shift_date,
     );
+
+    // If the given user has already picked up this shift,
+    if (existing_events.some((e) => e.type === SHIFT_EVENT_TYPE.PICKUP)) {
+        // And they are dropping it now,
+        if (event.type === SHIFT_EVENT_TYPE.DROP) {
+            // Remove the old pickup from the shift list
+            shift.history = shift.history.filter(
+                (e) =>
+                    !(
+                        e.initiator === event.initiator &&
+                        e.shift_date === event.shift_date &&
+                        (e.type === SHIFT_EVENT_TYPE.PICKUP ||
+                            e.type === SHIFT_EVENT_TYPE.DROP)
+                    ),
+            );
+            // If the user is trying to pickup this shift again, stop the request
+        } else if (event.type === SHIFT_EVENT_TYPE.PICKUP) {
+            return false;
+        }
+    } else if (
+        // Or if the user has previously dropped this shift,
+        existing_events.some((e) => e.type === SHIFT_EVENT_TYPE.DROP)
+    ) {
+        // And they are picking it now,
+        if (event.type === SHIFT_EVENT_TYPE.PICKUP) {
+            // Remove the old drop from the shift list
+            shift.history = shift.history.filter(
+                (e) =>
+                    !(
+                        e.initiator === event.initiator &&
+                        e.shift_date === event.shift_date &&
+                        (e.type === SHIFT_EVENT_TYPE.PICKUP ||
+                            e.type === SHIFT_EVENT_TYPE.DROP)
+                    ),
+            );
+            // If the user is trying to drop this shift again, stop the request
+        } else if (event.type === SHIFT_EVENT_TYPE.DROP) {
+            return false;
+        }
+    } else {
+        // Otherwise, the event request is valid, so add it to the shift history
+        shift.history.push(event);
+    }
+
+    // Update the schedule with the new shift history
+    schedule.shifts = schedule.shifts.map((sh) =>
+        sh.uuid === shift.uuid ? shift : sh,
+    );
+    return schedule.save();
+
+    //      {
+    //     // If the event types are the same, skip this one
+    //     if (existing_event.type === event.type) {
+    //         return false;
+    //         // If the event was a drop and is now being picked up or vice versa, remove the original
+    //     } else if (
+    //         (existing_event.type === SHIFT_EVENT_TYPE.PICKUP &&
+    //             event.type === SHIFT_EVENT_TYPE.DROP) ||
+    //         (existing_event.type === SHIFT_EVENT_TYPE.DROP &&
+    //             event.type === SHIFT_EVENT_TYPE.PICKUP)
+    //     ) {
+    //         shift.history = shift.history.filter(() => {});
+    //     } // Otherwise, continue
+    // }
+
+    // TODO: Consider deleting drop if assignee is the initiator of a pickup
+    // return Schedules.findOneAndUpdate(
+    //     // Find the schedule by UUID
+    //     { uuid: schedule_uuid, "shifts.uuid": shift_uuid },
+    //     // Push the new event to the shift's history array
+    //     { $push: { "shifts.$.history": event } },
+    //     // Return the updated schedule
+    //     { returnDocument: "after" },
+    // );
 }

--- a/server/routes/schedule.route.ts
+++ b/server/routes/schedule.route.ts
@@ -502,13 +502,22 @@ router.patch(
                 shift_uuid,
                 event_obj,
             );
-            if (!new_schedule) {
+            if (new_schedule === null) {
                 req.log.warn(
                     `An attempt was made to add an event to a shift in the schedule ` +
                         `with uuid ${schedule_uuid}, but that schedule or shift was not found`,
                 );
                 res.status(StatusCodes.NOT_FOUND).json({
                     error: `Schedule or shift not found.`,
+                });
+                return;
+            } else if (!new_schedule) {
+                req.log.warn(
+                    `An attempt was made to add an event to a shift in the schedule ` +
+                        `with uuid ${schedule_uuid} that has already been patched`,
+                );
+                res.status(StatusCodes.CONFLICT).json({
+                    error: `Request already submitted!`,
                 });
                 return;
             }

--- a/website/pages/admin/AdminKiosk.tsx
+++ b/website/pages/admin/AdminKiosk.tsx
@@ -3,6 +3,7 @@ import Schedule from "../../components/kiosks/admin/schedule/Schedule";
 import AdminLayout from "../../layouts/AdminLayout";
 import { ScheduleUUID, TSchedule } from "common/schedule";
 import {
+    addToast,
     Button,
     DateInput,
     DatePicker,
@@ -43,7 +44,7 @@ import {
     today,
     ZonedDateTime,
 } from "@internationalized/date";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import ShiftHistoryModal from "../../components/kiosks/admin/dashboard/ShiftHistoryModal";
 
 async function createShiftEvent({
@@ -137,7 +138,7 @@ export default function AdminKiosk() {
 
     const shiftEventMutation = useMutation({
         mutationFn: createShiftEvent,
-        onSuccess: (new_schedule) => {
+        onSuccess: (new_schedule, variables) => {
             queryClient.refetchQueries({
                 queryKey: [
                     "schedule",
@@ -148,9 +149,23 @@ export default function AdminKiosk() {
                     user_uuid,
                 ],
             });
+            const type = variables.event.type;
+            const type_text =
+                type === SHIFT_EVENT_TYPE.DROP ? "dropped" : "picked up";
+            addToast({
+                title: `Shift successfully ${type_text}`,
+                color: "success",
+            });
             setPopupShifts([]);
         },
-        onError: (err) => alert(err),
+        onError: (error: AxiosError<{ error: string }>) => {
+            addToast({
+                title:
+                    error.response?.data.error ??
+                    `Unknown error: ${error.message}`,
+                color: "danger",
+            });
+        },
     });
 
     const shiftCountMutation = useMutation({
@@ -586,6 +601,9 @@ export default function AdminKiosk() {
                                             color="primary"
                                             variant="bordered"
                                             className="col-span-2"
+                                            isDisabled={
+                                                shiftEventMutation.isPending
+                                            }
                                         >
                                             Drop
                                         </Button>
@@ -707,7 +725,7 @@ export default function AdminKiosk() {
                                                                     },
                                                                 );
                                                             }}
-                                                            isLoading={
+                                                            isDisabled={
                                                                 shiftEventMutation.isPending
                                                             }
                                                         >


### PR DESCRIPTION
Fix a bug where shifts could be dropped/picked up multiple times if the buttons were clicked in quick succession. Now, the buttons are visually disabled while the mutation is loading, and the backend event adding only accepts pickups on shifts that have been dropped and vice versa